### PR TITLE
patch_add_setValueFromBody_URL_fix

### DIFF
--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -111,10 +111,18 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
             body += data;
         });
         req.on('end', function () {
+            var arr = '',
+                cnt = 0,
+                response = [];
+                
             switch (command) {
                 case 'setBulk':
-                    that.adapter.log.debug('POST-' + command + ': body = ' + body);
-                    var arr = body.split('&');
+                    that.adapter.log.debug('POST-' + command + ': body = ' + JSON.stringify(body));
+                    
+                    //TODO: denke arr müsste von req.url geladen werden, 
+                    //TODO: der body spielt laut bisheriger Schnittstellenbeschreibung keine Rolle
+                    arr = req.url.substr(req.url.indexOf('?') + 1).split('&');
+                    //arr = body.split('&');				// hierher ruehrt das feiertage-Problem, body ist leer
 
                     for (var i = 0; i < arr.length; i++) {
                         arr[i] = arr[i].split('=');
@@ -126,14 +134,77 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                         if (values.prettyPrint === null)    values.prettyPrint = true;
                     }
 
-                    var cnt = 0;
-                    var response = [];
+                    cnt = 0;
                     that.adapter.log.debug('POST-' + command + ': values = ' + JSON.stringify(values));
                     for (var _id in values) {
                         if (_id === 'prettyPrint' || _id === 'user' || _id === 'pass') continue;
                         cnt++;
                         that.adapter.log.debug('"' + _id + '"');
                         findState(_id, values.user, function (err, id, originId) {
+                            if (err) {
+                                doResponse(res, 'plain', 500, headers, 'error: ' + err, values.prettyPrint);
+                                cnt = 0;
+                            } else if (!id) {
+                                response.push({error:  'error: datapoint "' + originId + '" not found'});
+                                if (!--cnt) doResponse(res, responseType, status, headers, response, values.prettyPrint);
+                            } else {
+                                var usedId = (values[originId]?originId:id);
+                                that.adapter.log.debug('POST-' + command + ' for id=' + id + ', oid=' + originId + 'used=' + usedId + ', value='+values[usedId]);
+                                if (values[usedId] === 'true') {
+                                    values[usedId] = true;
+                                } else if (values[usedId] === 'false') {
+                                    values[usedId] = false;
+                                } else if (!isNaN(values[usedId]) && values[usedId] == parseFloat(values[usedId])) {
+                                    values[usedId] = parseFloat(values[usedId]);
+                                }
+
+                                adapter.setForeignState(id, values[usedId], false, {user: values.user}, function (err, id) {
+                                    if (err) {
+                                        doResponse(res, 'plain', 500, headers, 'error: ' + err, values.prettyPrint);
+                                        cnt = 0;
+                                    } else {
+                                        status = 200;
+                                        adapter.log.debug('Add to Response: ' + JSON.stringify({id:  id, val: values[usedId]}));
+                                        response.push({id:  id, val: values[usedId]});
+                                        if (!--cnt) doResponse(res, responseType, status, headers, response, values.prettyPrint);
+                                    }
+                                });
+                            }
+                        });
+                    }
+                    if (!cnt) doResponse(res, responseType, status, headers, response, values.prettyPrint);
+                    break;
+
+                case 'setValueFromBody':
+                    //that.adapter.log.debug('POST-' + command + ': body = ' + JSON.stringify(body));					// "{0123456xx}"
+                    //that.adapter.log.debug('POST-' + command + ': req.url = ' + JSON.stringify(req.url));		// "/setValueFromBody?javascript.0.Nuki.Devices.NukiSL1.NukiBridgeResponse&prettyPrint"
+                    //that.adapter.log.debug('POST-' + command + ': valuesAA = ' + JSON.stringify(values));		// {"javascript.0.Nuki.Devices.NukiSL1.NukiBridgeResponse":null,"prettyPrint":true,"user":"system.user.admin"}
+ 
+                    arr = req.url.substr(req.url.indexOf('?') + 1).split('&');
+
+										//TODO: noch notwendig ? macht das ganze zumindest gegen Syntaxfehler robuster
+                    for (var j = 0; j < arr.length; j++) {
+                        arr[j] = arr[j].split('=');
+                        values[arr[j][0].trim()] = (arr[j][1] === undefined) ? null : arr[j][1];
+                    }
+                    
+										// only one datapoint supported
+										values[arr[0][0].trim()] = body;
+										//values[arr[0].trim()] = body;
+
+										//TODO: noch notwendig ?
+                    if (values.prettyPrint !== undefined) {
+                        if (values.prettyPrint === 'false') values.prettyPrint = false;
+                        if (values.prettyPrint === null)    values.prettyPrint = true;
+                    }
+
+                    cnt = 0;
+                    that.adapter.log.debug('POST-' + command + ': values = ' + JSON.stringify(values));
+                    for (var _id2 in values) {
+                        if (_id2 === 'prettyPrint' || _id2 === 'user' || _id2 === 'pass') continue;
+                        cnt++;
+                        that.adapter.log.debug('POST-' + command + ': _id2="' + _id2 + '"');
+                        findState(_id2, values.user, function (err, id, originId) {
                             if (err) {
                                 doResponse(res, 'plain', 500, headers, 'error: ' + err, values.prettyPrint);
                                 cnt = 0;
@@ -253,17 +324,18 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
 
     // static information
     var commandsPermissions = {
-        getPlainValue:  {type: 'state',    operation: 'read'},
-        get:            {type: 'state',    operation: 'read'},
-        getBulk:        {type: 'state',    operation: 'read'},
-        set:            {type: 'state',    operation: 'write'},
-        toggle:         {type: 'state',    operation: 'write'},
-        setBulk:        {type: 'state',    operation: 'write'},
-        getObjects:     {type: 'object',   operation: 'list'},
-        objects:        {type: 'object',   operation: 'list'},
-        states:         {type: 'state',    operation: 'list'},
-        getStates:      {type: 'state',    operation: 'list'},
-        help:           {type: '',         operation: ''}
+        getPlainValue:        {type: 'state',    operation: 'read'},
+        get:                  {type: 'state',    operation: 'read'},
+        getBulk:              {type: 'state',    operation: 'read'},
+        set:                  {type: 'state',    operation: 'write'},
+        toggle:               {type: 'state',    operation: 'write'},
+        setBulk:              {type: 'state',    operation: 'write'},
+        setValueFromBody:     {type: 'state',    operation: 'write'},
+        getObjects:           {type: 'object',   operation: 'list'},
+        objects:              {type: 'object',   operation: 'list'},
+        states:               {type: 'state',    operation: 'list'},
+        getStates:            {type: 'state',    operation: 'list'},
+        help:                 {type: '',         operation: ''}
     };
 
     this.commands = [];
@@ -726,14 +798,15 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                 if (this.app) request += '/' + this.namespace + '/';
                 var auth = '';
                 if (that.settings.auth) auth = 'user=UserName&pass=Password';
-                obj.getPlainValue = request + '/getPlainValue/stateID' + (auth ? '?' + auth : '');
-                obj.get           = request + '/get/stateID/?prettyPrint' + (auth ? '&' + auth : '');
-                obj.getBulk       = request + '/getBulk/stateID1,stateID2/?prettyPrint' + (auth ? '&' + auth : '');
-                obj.set           = request + '/set/stateID?value=1&prettyPrint' + (auth ? '&' + auth : '');
-                obj.toggle        = request + '/toggle/stateID&prettyPrint' + (auth ? '&' + auth : '');
-                obj.setBulk       = request + '/setBulk?stateID1=0.7&stateID2=0&prettyPrint' + (auth ? '&' + auth : '');
-                obj.objects       = request + '/objects?pattern=system.adapter.admin.0*&prettyPrint' + (auth ? '&' + auth : '');
-                obj.states        = request + '/states?pattern=system.adapter.admin.0*&prettyPrint' + (auth ? '&' + auth : '');
+                obj.getPlainValue      = request + '/getPlainValue/stateID' + (auth ? '?' + auth : '');
+                obj.get                = request + '/get/stateID/?prettyPrint' + (auth ? '&' + auth : '');
+                obj.getBulk            = request + '/getBulk/stateID1,stateID2/?prettyPrint' + (auth ? '&' + auth : '');
+                obj.set                = request + '/set/stateID?value=1&prettyPrint' + (auth ? '&' + auth : '');
+                obj.toggle             = request + '/toggle/stateID&prettyPrint' + (auth ? '&' + auth : '');
+                obj.setBulk            = request + '/setBulk?stateID1=0.7&stateID2=0&prettyPrint' + (auth ? '&' + auth : '');
+                obj.setValueFromBody   = request + '/setValueFromBody?stateID1' + (auth ? '&' + auth : '');
+                obj.objects            = request + '/objects?pattern=system.adapter.admin.0*&prettyPrint' + (auth ? '&' + auth : '');
+                obj.states             = request + '/states?pattern=system.adapter.admin.0*&prettyPrint' + (auth ? '&' + auth : '');
 
                 doResponse(res, responseType, status, headers, obj, true);
                 break;

--- a/test/testApi.js
+++ b/test/testApi.js
@@ -212,6 +212,7 @@ describe('Test RESTful API', function() {
         });
     });
 
+//TODO: Beim Get würde im Body nichts stehen!
     it('Test RESTful API: setBulk - must set values', function (done) {
         request('http://127.0.0.1:18183/setBulk/?system.adapter.simple-api.upload=50&system.adapter.simple-api.0.alive=false', function (error, response, body) {
             console.log('setBulk/?system.adapter.simple-api.upload=50&system.adapter.simple-api.0.alive=false => ' + body);
@@ -265,6 +266,11 @@ describe('Test RESTful API', function() {
         });
     });
 
+//TODO: Beim POST kann etwas im Body stehen, nicht aber laut der Schnittstellenbeschreibung, stateId und Wert sind in der URL kodiert
+//TODO: D. h., auch in den Testfällen müsste der body LEER sein!
+//            uri:    'https://127.0.0.1:18183/setBulk?system.adapter.simple-api.upload=50&system.adapter.simple-api.0.alive=false',
+//            method: 'POST',
+//            body:   ''
     it('Test RESTful API: setBulk(POST) - must set values', function (done) {
 
         request({
@@ -282,12 +288,39 @@ describe('Test RESTful API', function() {
             expect(obj[1].val).to.be.equal(false);
             expect(obj[1].id).to.equal('system.adapter.simple-api.0.alive');
 
+//TODO:             body = "";
             request('http://127.0.0.1:18183/getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive', function (error, response, body) {
                 console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
                 expect(obj[0].val).equal(50);
                 expect(obj[1].val).equal(false);
+                done();
+            });
+        });
+    });
+
+//TODO: Meine erste Testfunktion, bitte prüfen
+    it('Test RESTful API: setValueFromBody(POST) - must set one value', function (done) {
+        request({
+            uri: 'http://127.0.0.1:18183/setValueFromBody/?system.adapter.simple-api.upload',
+            method: 'POST',
+            body: '55'
+        }, function(error, response, body) {
+            console.log('setValueFromBody/?system.adapter.simple-api.upload => ' + JSON.stringify(body));
+            expect(error).to.be.not.ok;
+
+            var obj = JSON.parse(body);
+            expect(obj).to.be.ok;
+            expect(obj[0].val).to.be.equal(55);
+            expect(obj[0].id).to.equal('system.adapter.simple-api.upload');
+
+            body = "";
+            request('http://127.0.0.1:18183/getBulk/system.adapter.simple-api.upload', function (error, response, body) {
+                console.log('getBulk/system.adapter.simple-api.upload => ' + body);
+                expect(error).to.be.not.ok;
+                var obj = JSON.parse(body);
+                expect(obj[0].val).equal(55);
                 done();
             });
         });

--- a/test/testSsl.js
+++ b/test/testSsl.js
@@ -122,6 +122,11 @@ describe('Test RESTful API SSL', function() {
         });
     });
 
+//TODO: Beim POST kann etwas im Body stehen, nicht aber laut der Schnittstellenbeschreibung, stateId und Wert sind in der URL kodiert
+//TODO: D. h., auch in den Testfällen müsste der body LEER sein!
+//            uri:    'https://127.0.0.1:18183/setBulk?user=admin&pass=iobroker&system.adapter.simple-api.upload=50&system.adapter.simple-api.0.alive=false',
+//            method: 'POST',
+//            body:   ''
     it('Test RESTful API SSL: setBulk(POST) - must set values', function (done) {
 
         request({
@@ -139,12 +144,39 @@ describe('Test RESTful API SSL', function() {
             expect(obj[1].val).to.be.equal(false);
             expect(obj[1].id).to.equal('system.adapter.simple-api.0.alive');
 
+//TODO:             body = "";
             request('https://127.0.0.1:18183/getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive?user=admin&pass=iobroker', function (error, response, body) {
                 console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
                 expect(obj[0].val).equal(50);
                 expect(obj[1].val).equal(false);
+                done();
+            });
+        });
+    });
+
+//TODO: Meine erste Testfunktion, bitte prüfen
+    it('Test RESTful API SSL: setValueFromBody(POST) - must set values', function (done) {
+        request({
+            uri:    'https://127.0.0.1:18183/setValueFromBody?user=admin&pass=iobroker&system.adapter.simple-api.upload',
+            method: 'POST',
+            body:   '55'
+        }, function(error, response, body) {
+            console.log('setValueFromBody/?system.adapter.simple-api.upload => ' + JSON.stringify(body));
+            expect(error).to.be.not.ok;
+
+            var obj = JSON.parse(body);
+            expect(obj).to.be.ok;
+            expect(obj[0].val).to.be.equal(55);
+            expect(obj[0].id).to.equal('system.adapter.simple-api.upload');
+						
+            body = "";
+            request('https://127.0.0.1:18183/getBulk/system.adapter.simple-api.upload?user=admin&pass=iobroker', function (error, response, body) {
+                console.log('getBulk/system.adapter.simple-api.upload => ' + body);
+                expect(error).to.be.not.ok;
+                var obj = JSON.parse(body);
+                expect(obj[0].val).equal(55);
                 done();
             });
         });


### PR DESCRIPTION
Du solltest dir die setBulk-Methode noch einmal ansehen. So wie ich die Schnittstellenbeschreibung verstanden habe, wird auch beim POST stateId=value in der URL kodiert. Habe kein Bsp. gesehen, dass das im Body stehen darf. Technisch wäre es natürlich möglich, auch eine Mischung aus beiden, was ich dann aber für unsauber halten würde. Ausgenommen user/password bei SSL würde ich in der URL belassen (wie auch jetzt schon).