### PR TITLE
Return datapoint IDs on getBulk

### DIFF
--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -585,7 +585,7 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                     break;
                 }
                 var bcnt = oId.length;
-                response = [];
+                response = {};
                 for (var b = 0; b < oId.length; b++) {
                     getState(oId[b], values.user, function (err, state, id, originId) {
                         if (err) {
@@ -596,9 +596,11 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                             }
                             doResponse(res, responseType, status, headers, 'error: ' + err, values.prettyPrint);
                         } else {
-                            if (id) status = 200;
-                            state = state || {};
-                            response.push({val: state.val, ts: state.ts});
+                            if (id) {
+                                status = 200;
+                                state = state || {};
+                                response[id] = {val: state.val, ts: state.ts};
+                            }
                             if (!--bcnt) doResponse(res, responseType, status, headers, response, values.prettyPrint);
                         }
                     });

--- a/test/testApi.js
+++ b/test/testApi.js
@@ -320,8 +320,8 @@ describe('Test RESTful API', function() {
                 console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(50);
-                expect(obj[1].val).equal(false);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(50);
+                expect(obj['system.adapter.simple-api.0.alive'].val).equal(false);
                 expect(response.statusCode).to.equal(200);
                 done();
             });
@@ -385,9 +385,9 @@ describe('Test RESTful API', function() {
                 console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive,javascript.0.test-string => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(50);
-                expect(obj[1].val).equal(false);
-                expect(obj[2].val).equal('bla&fasel.foo=hummer hey');
+                expect(obj['system.adapter.simple-api.upload'].val).equal(50);
+                expect(obj['system.adapter.simple-api.0.alive'].val).equal(false);
+                expect(obj['javascript.0.test-string'].val).equal('bla&fasel.foo=hummer hey');
                 expect(response.statusCode).to.equal(200);
                 done();
             });
@@ -416,8 +416,8 @@ describe('Test RESTful API', function() {
                 console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(51);
-                expect(obj[1].val).equal(false);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(51);
+                expect(obj['system.adapter.simple-api.0.alive'].val).equal(false);
                 expect(response.statusCode).to.equal(200);
                 done();
             });
@@ -443,7 +443,7 @@ describe('Test RESTful API', function() {
                 console.log('getBulk/system.adapter.simple-api.upload => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(55);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(55);
                 expect(response.statusCode).to.equal(200);
                 done();
             });

--- a/test/testApiAsUser.js
+++ b/test/testApiAsUser.js
@@ -369,12 +369,12 @@ describe('Test RESTful API as User', function() {
             expect(response.statusCode).to.equal(200);
 
             request('http://127.0.0.1:18183/getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive,javascript.0.test', function (error, response, body) {
-                console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive&javascript.0.test => ' + body);
+                console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive,javascript.0.test => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(50);
-                expect(obj[1].val).equal(false);
-                expect(obj[2].val).equal(3);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(50);
+                expect(obj['system.adapter.simple-api.0.alive'].val).equal(false);
+                expect(obj['javascript.0.test'].val).equal(3);
                 expect(response.statusCode).to.equal(200);
                 done();
             });
@@ -432,9 +432,9 @@ describe('Test RESTful API as User', function() {
                 console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive,javascript.0.test => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(50);
-                expect(obj[1].val).equal(false);
-                expect(obj[2].val).equal(4);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(50);
+                expect(obj['system.adapter.simple-api.0.alive'].val).equal(false);
+                expect(obj['javascript.0.test'].val).equal(4);
                 expect(response.statusCode).to.equal(200);
                 done();
             });
@@ -464,8 +464,8 @@ describe('Test RESTful API as User', function() {
                 console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(51);
-                expect(obj[1].val).equal(false);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(51);
+                expect(obj['system.adapter.simple-api.0.alive'].val).equal(false);
                 expect(response.statusCode).to.equal(200);
                 done();
             });
@@ -491,7 +491,7 @@ describe('Test RESTful API as User', function() {
                 console.log('getBulk/system.adapter.simple-api.upload => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(55);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(55);
                 expect(response.statusCode).to.equal(200);
                 done();
             });

--- a/test/testSsl.js
+++ b/test/testSsl.js
@@ -150,8 +150,8 @@ describe('Test RESTful API SSL', function() {
                 console.log('getBulk/system.adapter.simple-api.upload,system.adapter.simple-api.0.alive => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(50);
-                expect(obj[1].val).equal(false);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(50);
+                expect(obj['system.adapter.simple-api.0.alive'].val).equal(false);
                 expect(response.statusCode).to.equal(200);
                 done();
             });
@@ -178,7 +178,7 @@ describe('Test RESTful API SSL', function() {
                 console.log('getBulk/system.adapter.simple-api.upload => ' + body);
                 expect(error).to.be.not.ok;
                 var obj = JSON.parse(body);
-                expect(obj[0].val).equal(55);
+                expect(obj['system.adapter.simple-api.upload'].val).equal(55);
                 expect(response.statusCode).to.equal(200);
                 done();
             });


### PR DESCRIPTION
Former behavior was to return all requested datapoint states in a random order as an array without any chance to identify which value belongs to which datapoint. With this change getBulk returns an addressable object with the values.