### PR TITLE
Comands for JSON/Simple-JSON Grafana Plugin added

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,8 +443,99 @@ Get the list of all states for pattern. If no pattern specified all states as JS
     }
 </pre>
 
+### search
+Is a data source (History, SQL) in the configuration is set, then only the data points known to the data source are listed.
+If the option 'List all data points' has been activated or no data source has been specified, all data points will be listed.
+
+<pre>http://ip:8087/search?pattern=system.adapter.admin.0*&prettyPrint</pre>
+<pre>
+  {
+    "system.adapter.admin.0.outputCount",
+    "system.adapter.admin.0.inputCount",
+    "system.adapter.admin.0.uptime",
+    "system.adapter.admin.0.memRss",
+    "system.adapter.admin.0.memHeapTotal",
+    "system.adapter.admin.0.memHeapUsed",
+    "system.adapter.admin.0.cputime",
+    "system.adapter.admin.0.cpu",
+    "system.adapter.admin.0.connected",
+    "system.adapter.admin.0.alive"
+  }
+</pre>
+
+### query
+If a data source (History, SQL) has been specified, the data from the specified data points are read out for the specified period.
+
+<pre>http://ip:8087/query/system.host.iobroker-dev.load,system.host.iobroker-dev.memHeapUsed/?prettyPrint&dateFrom=2019-06-08T01:00:00.000Z&dateTo=2019-06-08T01:00:10.000Z</pre>
+<pre>
+  [
+    {
+      "target": "system.host.iobroker-dev.load",
+      "datapoints": [
+        [
+          0.12,
+          1559955600000
+        ],
+        [
+          0.46,
+          1559955601975
+        ],
+        [
+          0.44,
+          1559955610000
+        ]
+      ]
+    },
+    {
+      "target": "system.host.iobroker-dev.memHeapUsed",
+      "datapoints": [
+        [
+          23.01,
+          1559955600000
+        ],
+        [
+          22.66,
+          1559955601975
+        ],
+        [
+          22.69,
+          1559955610000
+        ]
+      ]
+    }
+  ]
+</pre>
+
+If no data source was specified or the noHistory parameter is passed, then only the current value of the data point is read out.
+
+<pre>http://ip:8087/query/system.host.iobroker-dev.load,system.host.iobroker-dev.memHeapUsed/?prettyPrint&noHistory=true</pre>
+<pre>
+  [
+    {
+      "target": "system.host.iobroker-dev.load",
+      "datapoints": [
+        [
+          0.58,
+          1559970500342
+        ]
+      ]
+    },
+    {
+      "target": "system.host.iobroker-dev.memHeapUsed",
+      "datapoints": [
+        [
+          21.53,
+          1559970500342
+        ]
+      ]
+    }
+  ]
+</pre>
 
 ## Changelog
+
+### 2.0.3 (2019-06-08)
+* (Marco.K) Added command set for the Grafana plugins JSON / SimpleJSON.
 
 ### 2.0.2 (2018-12-17)
 * (Apollon77) fix decoding for state Ids with # in it

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Call in browser ```http://ipaddress:8087/help``` to get the help about API. The 
   "objects": "http://ipaddress:8087/objects?pattern=system.adapter.admin.0*&prettyPrint",
   "objects": "http://ipaddress:8087/objects?pattern=system.adapter.admin.0*&type=adapter&prettyPrint",
   "states": "http://ipaddress:8087/states?pattern=system.adapter.admin.0*&prettyPrint"
+  "search": "http://192.168.0.24:8087/search?pattern=system.adapter.admin.0*&prettyPrint",
+  "query": "http://192.168.0.24:8087/query/stateID1,stateID2/?prettyPrint"
+  "query": "http://192.168.0.24:8087/query/stateID1,stateID2/?noHistory=true&prettyPrint"
+  "query": "http://192.168.0.24:8087/query/stateID1,stateID2/?dateFrom=2019-06-06T12:00:00.000Z&d&prettyPrint"
+  "query": "http://192.168.0.24:8087/query/stateID1,stateID2/?dateFrom=2019-06-06T12:00:00.000Z&dateTo=2019-06-06T12:00:00.000Z&prettyPrint"
 }
 ```
 
@@ -110,6 +115,15 @@ Of course the data point *javascript.0.test* must exist.
 
 ### states
 
+### search
+    Is a data source (History, SQL) in the configuration is set, then only the data points known to the data source are listed.
+    If the option 'List all data points' has been activated or no data source has been specified, all data points will be listed.
+    This command is needed for the Grafana JSON / SimpleJSON Plugin.
+
+### query
+    If a data source (History, SQL) has been specified, the data from the specified data points are read out for the specified period, otherwise only the current value is read out.
+    This command is needed for the Grafana JSON / SimpleJSON Plugin.
+    
 ### help
 Gives [this](#usage) output back
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -53,6 +53,11 @@
                 $('.defaultUser').show();
             }
         }
+        if ($('#dataSource').val()) {
+            $('.allDatapoints').show();
+        } else {
+            $('.allDatapoints').hide();
+        }
     }
 
     // the function loadSettings has to exist ...
@@ -82,6 +87,7 @@
             } else {
                 $('#' + key + '.value').val(settings[key]).on('change', function() {
                     if (key === 'webInstance') showHideSettings();
+                    if (key === 'dataSource') showHideSettings();
                     onChange();
                 }).on('keyup', function() {
                     onChange();
@@ -201,7 +207,7 @@
         <tr><td><label for="dataSource" class="translate">Select data source:</label></td><td><select class="value" id="dataSource">
             <option value=""  class="translate">none</option>
         </select></td></tr>
-
+        <tr class="allDataPoints"><td><label for="allDatapoints" class="translate">Show all datapoints:</label></td><td><input  class="value" id="allDatapoints" type="checkbox" /></td></tr>
     </table>
 </div>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -207,7 +207,7 @@
         <tr><td><label for="dataSource" class="translate">Select data source:</label></td><td><select class="value" id="dataSource">
             <option value=""  class="translate">none</option>
         </select></td></tr>
-        <tr class="allDataPoints"><td><label for="allDatapoints" class="translate">Show all datapoints:</label></td><td><input  class="value" id="allDatapoints" type="checkbox" /></td></tr>
+        <tr class="allDataPoints"><td><label for="allDatapoints" class="translate">List all datapoints:</label></td><td><input  class="value" id="allDatapoints" type="checkbox" /></td></tr>
     </table>
 </div>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -111,6 +111,35 @@
         } else {
             showHideSettings();
         }
+
+        if (typeof getAdapterInstances !== 'undefined') {
+            getAdapterInstances("history", function (result) {
+                if (result) {
+                    var text = '';
+                    for (var r = 0; r < result.length; r++) {
+                        var name = result[r]._id.substring('system.adapter.'.length);
+                        text += '<option value="' + name + '" ' + (settings.dataSource === name ? 'selected' : '') + '>' + name + '</option>';
+                    }
+                    $('#dataSource').append(text);
+                    showHideSettings();
+                }
+            });
+
+            getAdapterInstances("sql", function (result) {
+                if (result) {
+                    var text = '';
+                    for (var r = 0; r < result.length; r++) {
+                        var name = result[r]._id.substring('system.adapter.'.length);
+                        text += '<option value="' + name + '" ' + (settings.dataSource === name ? 'selected' : '') + '>' + name + '</option>';
+                    }
+                    $('#dataSource').append(text);
+                    showHideSettings();
+                }
+            });            
+        } else {
+            showHideSettings();
+        }
+        
         onChange(false);
     }
 
@@ -169,6 +198,10 @@
         <tr class="no-if-extend le-settings"><td><label for="leEnabled" class="translate">Use Lets Encrypt certificates:</label></td><td><input  class="value" id="leEnabled"   type="checkbox" /></td></tr>
         <tr class="no-if-extend le-settings le-sub-settings"><td><label for="leUpdate" class="translate">Use this instance for automatic update:</label></td><td><input  class="value" id="leUpdate" type="checkbox" /></td></tr>
         <tr class="no-if-extend le-settings le-sub-settings le-sub-settings-update"><td><label for="lePort" class="translate">Port to check the domain:</label></td><td><input class="value number" id="lePort" type="number" size="5" maxlength="5" /></td></tr>
+        <tr><td><label for="dataSource" class="translate">Select data source:</label></td><td><select class="value" id="dataSource">
+            <option value=""  class="translate">none</option>
+            <option value="*" class="translate">all</option>
+        </select></td></tr>
 
     </table>
 </div>

--- a/admin/index.html
+++ b/admin/index.html
@@ -200,7 +200,6 @@
         <tr class="no-if-extend le-settings le-sub-settings le-sub-settings-update"><td><label for="lePort" class="translate">Port to check the domain:</label></td><td><input class="value number" id="lePort" type="number" size="5" maxlength="5" /></td></tr>
         <tr><td><label for="dataSource" class="translate">Select data source:</label></td><td><select class="value" id="dataSource">
             <option value=""  class="translate">none</option>
-            <option value="*" class="translate">all</option>
         </select></td></tr>
 
     </table>

--- a/admin/index.html
+++ b/admin/index.html
@@ -118,46 +118,36 @@
             showHideSettings();
         }
 
-        if (typeof getAdapterInstances !== 'undefined') {
-            getAdapterInstances("history", function (result) {
-                if (result) {
-                    var text = '';
-                    for (var r = 0; r < result.length; r++) {
-                        var name = result[r]._id.substring('system.adapter.'.length);
-                        text += '<option value="' + name + '" ' + (settings.dataSource === name ? 'selected' : '') + '>' + name + '</option>';
-                    }
-                    $('#dataSource').append(text);
-                    showHideSettings();
-                }
-            });
-
-            getAdapterInstances("sql", function (result) {
-                if (result) {
-                    var text = '';
-                    for (var r = 0; r < result.length; r++) {
-                        var name = result[r]._id.substring('system.adapter.'.length);
-                        text += '<option value="' + name + '" ' + (settings.dataSource === name ? 'selected' : '') + '>' + name + '</option>';
-                    }
-                    $('#dataSource').append(text);
-                    showHideSettings();
-                }
-            });            
-
-            getAdapterInstances("influxdb", function (result) {
-                if (result) {
-                    var text = '';
-                    for (var r = 0; r < result.length; r++) {
-                        var name = result[r]._id.substring('system.adapter.'.length);
-                        text += '<option value="' + name + '" ' + (settings.dataSource === name ? 'selected' : '') + '>' + name + '</option>';
-                    }
-                    $('#dataSource').append(text);
-                    showHideSettings();
-                }
-            });            } else {
-            showHideSettings();
-        }
+        getHistoryInstances(settings);
         
         onChange(false);
+    }
+
+
+    function getHistoryInstances(settings) {
+        socket.emit('getObjectView', 'system', 'instance', {startkey: 'system.adapter.', endkey: 'system.adapter.\u9999'}, function (err, doc) {
+            if (err) {
+                console.error(err);
+            } else {
+                if (doc.rows.length) {
+                    var result = [];
+                    for (var i = 0; i < doc.rows.length; i++) {
+                        result.push(doc.rows[i].value);
+                    }
+                    result = result.filter(function (adp) {
+                        return adp && adp.common && adp.common.getHistory;
+                    });
+                    
+                    var text = '';
+                    for (var r = 0; r < result.length; r++) {
+                        var name = result[r]._id.substring('system.adapter.'.length);
+                        text += '<option value="' + name + '" ' + (settings.dataSource === name ? 'selected' : '') + '>' + name + '</option>';
+                    }
+                    $('#dataSource').append(text);
+                    showHideSettings();
+                }
+            }
+        });
     }
 
     // ... and the function save has to exist.

--- a/admin/index.html
+++ b/admin/index.html
@@ -142,7 +142,18 @@
                     showHideSettings();
                 }
             });            
-        } else {
+
+            getAdapterInstances("influxdb", function (result) {
+                if (result) {
+                    var text = '';
+                    for (var r = 0; r < result.length; r++) {
+                        var name = result[r]._id.substring('system.adapter.'.length);
+                        text += '<option value="' + name + '" ' + (settings.dataSource === name ? 'selected' : '') + '>' + name + '</option>';
+                    }
+                    $('#dataSource').append(text);
+                    showHideSettings();
+                }
+            });            } else {
             showHideSettings();
         }
         

--- a/admin/words.js
+++ b/admin/words.js
@@ -15,6 +15,7 @@ systemDictionary = {
     "Extend WEB adapter:":    {"en": "Extend WEB adapter:",     "de": "Erweitere WEB Adapter:",  "ru": "Подключить к WEB драйверу:"},
     "all":                    {"en": "all",                     "de": "alle",                    "ru": "все"},
     "Listen on all IPs":      {"en": "Listen on all IPs",       "de": "Alle IPs zulassen",       "ru": "Открыть для всех IP адресов"},
+    "Select data source:":    {"en": "Select data source:",     "de": "Datenquelle auswählen:",  "ru": "Выберите источник данных"},
     "Let's Encrypt settings": {
         "en": "Let's Encrypt settings",
         "de": "Einstellungen Let's Encrypt",

--- a/admin/words.js
+++ b/admin/words.js
@@ -4,7 +4,7 @@ systemDictionary = {
         "ru": "simpleAPI adapter settings"
     },
     "Run as:":          {"de": "Laufen unter Anwender:", "ru": "Запустить от пользователя:"},
-    "Allow only when User is Owner:":          {"de": "Nue erlauben wenn Anwender auch Besitzer ist:", "ru": "Allow only when User is Owner:"},
+    "Allow only when User is Owner:":          {"de": "Nur erlauben wenn Anwender auch Besitzer ist:", "ru": "Allow only when User is Owner:"},
     "IP:":              {"de": "IP:",                        "ru": "IP:"},
     "Port:":            {"de": "Port:",                      "ru": "Порт:"},
     "Secure(HTTPS):":   {"de": "Verschlüsselung(HTTPS):",    "ru": "Шифрование(HTTPS):"},
@@ -15,7 +15,8 @@ systemDictionary = {
     "Extend WEB adapter:":    {"en": "Extend WEB adapter:",     "de": "Erweitere WEB Adapter:",  "ru": "Подключить к WEB драйверу:"},
     "all":                    {"en": "all",                     "de": "alle",                    "ru": "все"},
     "Listen on all IPs":      {"en": "Listen on all IPs",       "de": "Alle IPs zulassen",       "ru": "Открыть для всех IP адресов"},
-    "Select data source:":    {"en": "Select data source:",     "de": "Datenquelle auswählen:",  "ru": "Выберите источник данных"},
+    "Select data source:":    {"en": "Select data source:",     "de": "Datenquelle auswählen:",  "ru": "Выберите источник данных:"},
+    "List all datapoints:":   {"en": "List all datapoints:",    "de": "Alle Datenpunkte auflisten:",  "ru": "Список всех точек данных:"},
     "Let's Encrypt settings": {
         "en": "Let's Encrypt settings",
         "de": "Einstellungen Let's Encrypt",

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,19 @@
 {
     "common": {
         "name": "simple-api",
-        "version": "2.0.2",
+        "version": "2.0.3",
         "news": {
+            "2.0.3": {
+                "en": "Added command set for the Grafana plugins JSON / SimpleJSON.",
+                "de": "Befehlssatz für die Grafana-Plugins JSON / SimpleJSON hinzugefügt.",
+                "ru": "Добавлен набор команд для плагинов Grafana JSON / SimpleJSON.",
+                "pt": "Adicionado conjunto de comandos para os plugins Grafana JSON / SimpleJSON.",
+                "nl": "Toegevoegde opdrachtset voor de Grafana-plug-ins JSON / SimpleJSON.",
+                "fr": "Ajout du jeu de commandes pour les plugins Grafana JSON / SimpleJSON.",
+                "it": "Aggiunto set di comandi per i plugin Grafana JSON / SimpleJSON.",
+                "es": "Agregado conjunto de comandos para los complementos de Grafana JSON / SimpleJSON.",
+                "pl": "Dodano zestaw poleceń dla wtyczek Grafana JSON / SimpleJSON."
+            },
             "2.0.2": {
                 "en": "Fix decoding of #",
                 "de": "Decodierung von # korrigieren",
@@ -81,7 +92,8 @@
         "desc":                     "This adapter allows to read and write ioBroker objects and state with web RESTful API",
         "authors": [
             "bluefox <dogafox@gmail.com>",
-            "Apollon77 <ingo@fischer-ka.de>"
+            "Apollon77 <ingo@fischer-ka.de>",
+            "Marco.K <marco@kaminski-net.de>"
         ],
         "license":                  "MIT",
         "platform":                 "Javascript/Node.js",
@@ -113,6 +125,9 @@
 
         "leEnabled":                false,
         "leUpdate":                 false,
-        "leCheckPort":              80
+        "leCheckPort":              80,
+
+        "dataSource":               "",
+        "allDatapoints":            false
     }
 }

--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -269,7 +269,7 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                     break;
 
                 case 'search':
-                    var target = body.target || "";
+                    var target = JSON.parse(body).target || "";
                     that.adapter.log.debug("[SEARCH] target = " + target);
 
                     adapter.getForeignStates(values.pattern || target + '*', {
@@ -296,6 +296,48 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                     break;
 
                 case 'query':
+                    var targets = JSON.parse(body).targets || [];
+                    that.adapter.log.debug("[QUERY] targets = " + JSON.stringify(targets));
+                    
+                    oId = [];
+                    targets.forEach(t => {
+                        oId.push(t.target);
+                    });
+
+                    if (!oId.length || !oId[0]) {
+                        doResponse(res, responseType, status, headers, {error: 'no datapoints given'}, values.prettyPrint);
+                        break;
+                    }
+                    let bcnt = oId.length;
+                    var list = [];
+                    for (let b = 0; b < oId.length; b++) {
+                        getState(oId[b], values.user, (err, state, id, originId) => {
+                            if (err) {
+                                bcnt = 0;
+                                status = 500;
+                                if (err.indexOf('permissionError') !== -1) {
+                                    status = 401;
+                                }
+                                doResponse(res, responseType, status, headers, 'error: ' + err, values.prettyPrint);
+                            } else {
+                                if (id) status = 200;
+                                state = state || {};
+
+                                var element = {};
+                                element.target = id;
+                                element.datapoints = [[state.val, state.ts]];
+
+                                list.push(element);
+                                if (!--bcnt) {
+                                    that.adapter.log.debug("[QUERY] list = " + JSON.stringify(list));
+                                    doResponse(res, responseType, status, headers, list, values.prettyPrint);
+                                }
+                            }
+                        });
+                    }
+                    if (!bcnt) {
+                        doResponse(res, responseType, status, headers, list, values.prettyPrint);
+                    }
                     break;
                 
                 case 'annotations':

--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -403,6 +403,9 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                     break;
                 
                 case 'annotations':
+                    // iobroker does not support annontations
+                    that.adapter.log.debug("[ANNOTATIONS]");
+                    doResponse(res, responseType, 200, headers, [], values.prettyPrint);
                     break;
 
                 default:
@@ -504,6 +507,9 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
         objects: {type: 'object', operation: 'list'},
         states: {type: 'state', operation: 'list'},
         getStates: {type: 'state', operation: 'list'},
+        search: {type: 'state', operation: 'list'},
+        query: {type: 'state', operation: 'read'},
+        annotations: {type: '', operation: ''},
         help: {type: '', operation: ''}
     };
 
@@ -1071,6 +1077,139 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                 });
                 break;
 
+            case 'search':
+                if (adapter.config.dataSource && adapter.config.allDatapoints !== true) {
+                    adapter.sendTo(adapter.config.dataSource, 'getEnabledDPs', {}, function (result) {
+                        status = 200;
+                        oId = [];
+                        for (var id in result) {
+                            if( result.hasOwnProperty(id) ) {
+                                oId.push(id);
+                            }                                 
+                        }
+                        doResponse(res, responseType, status, headers, oId, values.prettyPrint);
+                    });
+                } else {
+                    that.adapter.log.debug("[SEARCH] target = " + parts[2]);
+
+                    adapter.getForeignStates(values.pattern || parts[2] || '*', {
+                        user: values.user,
+                        limitToOwnerRights: that.adapter.config.onlyAllowWhenUserIsOwner
+                    }, (err, list) => {
+                        if (err) {
+                            status = 500;
+                            if (err.indexOf('permissionError') !== -1) {
+                                status = 401;
+                            }
+                            doResponse(res, responseType, status, headers, {error: JSON.stringify(err)}, values.prettyPrint);
+                        } else {
+                            status = 200;
+                            oId = [];
+                            for (var id in list) {
+                                if( list.hasOwnProperty(id) ) {
+                                    oId.push(id);
+                                }                                 
+                            }
+                            doResponse(res, responseType, status, headers, oId, values.prettyPrint);
+                        }
+                    });
+                }
+                break;
+
+            case 'query':
+                that.adapter.log.debug(JSON.stringify(parts));
+                that.adapter.log.debug(JSON.stringify(values));
+
+                let dateFrom = Date.now();
+                let dateTo = Date.now();
+
+                if (values.dateFrom) {
+                    dateFrom = Date.parse(values.dateFrom);
+                }
+                if (values.dateTo) {
+                    dateTo = Date.parse(values.dateTo);
+                }
+
+                if (!oId.length || !oId[0]) {
+                    doResponse(res, responseType, status, headers, {error: 'no datapoints given'}, values.prettyPrint);
+                    break;
+                }
+                let tcnt = oId.length;
+                response = [];
+                for (let b = 0; b < oId.length; b++) {
+                    if (that.adapter.config.dataSource && !(values.noHistory && values.noHistory === 'true')) {
+                        that.adapter.log.debug("Read data from: " + that.adapter.config.dataSource);
+
+                        that.adapter.sendTo(that.adapter.config.dataSource, 'getHistory', {
+                            id: oId[b],
+                            options: {
+                                start:      dateFrom,
+                                end:        dateTo,
+                                aggregate: 'onchange'
+                            }
+                        }, function (result, step, error) {
+                            if (!error) status = 200;
+
+                            that.adapter.log.debug("[QUERY] sendTo result = " + JSON.stringify(result));
+
+                            var element = {};
+                            element.target = oId[b];
+                            element.datapoints = [];
+
+                            for (var i = 0; i < result.result.length; i++) {
+                                var datapoint = [result.result[i].val, result.result[i].ts];
+                                element.datapoints.push(datapoint);
+                            }
+
+                            response.push(element);
+
+                            if (!--tcnt) {
+                                that.adapter.log.debug("[QUERY] response = " + JSON.stringify(response));
+                                doResponse(res, responseType, status, headers, response, values.prettyPrint);
+                            }
+                        });
+                    } else {
+                        that.adapter.log.debug("Read last state");
+
+                        getState(oId[b], values.user, (err, state, id, originId) => {
+                            var element = {};
+                            element.target = id;
+                            element.datapoints = [];
+
+                            if (err) {
+                                tcnt = 0;
+                                status = 500;
+                                if (err.indexOf('permissionError') !== -1) {
+                                    status = 401;
+                                }
+                                doResponse(res, responseType, status, headers, 'error: ' + err, values.prettyPrint);
+                            } else {
+                                if (id) status = 200;
+                                state = state || {};
+
+                                element.datapoints = [[state.val, state.ts]];
+
+                                response.push(element);
+
+                                if (!--tcnt) {
+                                    that.adapter.log.debug("[QUERY] response = " + JSON.stringify(response));
+                                    doResponse(res, responseType, status, headers, response, values.prettyPrint);
+                                }
+                            }
+                        });
+                    }
+                }
+                if (!tcnt) {
+                    doResponse(res, responseType, status, headers, response, values.prettyPrint);
+                }                
+                break;
+            
+            case 'annotations':
+                // iobroker does not support annontations
+                that.adapter.log.debug("[ANNOTATIONS]");
+                doResponse(res, responseType, 200, headers, [], values.prettyPrint);
+                break;
+
             case 'help':
             // is default behaviour too
             default:
@@ -1092,6 +1231,8 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                 obj.setValueFromBody = request + '/setValueFromBody?stateID1' + (auth ? '&' + auth : '');
                 obj.objects = request + '/objects?pattern=system.adapter.admin.0*&prettyPrint' + (auth ? '&' + auth : '');
                 obj.states = request + '/states?pattern=system.adapter.admin.0*&prettyPrint' + (auth ? '&' + auth : '');
+                obj.search = request + '/search?pattern=system.adapter.admin.0*&prettyPrint' + (auth ? '&' + auth : '');
+                obj.query = request + '/query/stateID1,stateID2/?dateFrom=2019-06-06T12:00:00.000Z&dateTo=2019-06-06T12:00:00.000Z&noHistory=false&prettyPrint' + (auth ? '&' + auth : '');
 
                 doResponse(res, responseType, status, headers, obj, true);
                 break;

--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -268,6 +268,39 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                 }
                     break;
 
+                case 'search':
+                    var target = body.target || "";
+                    that.adapter.log.debug("[SEARCH] target = " + target);
+
+                    adapter.getForeignStates(values.pattern || target + '*', {
+                        user: values.user,
+                        limitToOwnerRights: that.adapter.config.onlyAllowWhenUserIsOwner
+                    }, (err, list) => {
+                        if (err) {
+                            status = 500;
+                            if (err.indexOf('permissionError') !== -1) {
+                                status = 401;
+                            }
+                            doResponse(res, responseType, status, headers, {error: JSON.stringify(err)}, values.prettyPrint);
+                        } else {
+                            status = 200;
+                            oId = [];
+                            for (var id in list) {
+                                if( list.hasOwnProperty(id) ) {
+                                    oId.push(id);
+                                  }                                 
+                            }
+                            doResponse(res, responseType, status, headers, oId, values.prettyPrint);
+                        }
+                    });
+                    break;
+
+                case 'query':
+                    break;
+                
+                case 'annotations':
+                    break;
+
                 default:
                     doResponse(res, responseType, status, headers, {error: 'command ' + command + ' unknown'}, values.prettyPrint);
                     break;

--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -269,30 +269,43 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                     break;
 
                 case 'search':
-                    var target = JSON.parse(body).target || "";
-                    that.adapter.log.debug("[SEARCH] target = " + target);
-
-                    adapter.getForeignStates(values.pattern || target + '*', {
-                        user: values.user,
-                        limitToOwnerRights: that.adapter.config.onlyAllowWhenUserIsOwner
-                    }, (err, list) => {
-                        if (err) {
-                            status = 500;
-                            if (err.indexOf('permissionError') !== -1) {
-                                status = 401;
-                            }
-                            doResponse(res, responseType, status, headers, {error: JSON.stringify(err)}, values.prettyPrint);
-                        } else {
+                    if (adapter.config.dataSource && adapter.config.allDatapoints !== true) {
+                        adapter.sendTo(adapter.config.dataSource, 'getEnabledDPs', {}, function (result) {
                             status = 200;
                             oId = [];
-                            for (var id in list) {
-                                if( list.hasOwnProperty(id) ) {
+                            for (var id in result) {
+                                if( result.hasOwnProperty(id) ) {
                                     oId.push(id);
-                                  }                                 
+                                }                                 
                             }
                             doResponse(res, responseType, status, headers, oId, values.prettyPrint);
-                        }
-                    });
+                        });
+                    } else {
+                        var target = JSON.parse(body).target || "";
+                        that.adapter.log.debug("[SEARCH] target = " + target);
+
+                        adapter.getForeignStates(values.pattern || target + '*', {
+                            user: values.user,
+                            limitToOwnerRights: that.adapter.config.onlyAllowWhenUserIsOwner
+                        }, (err, list) => {
+                            if (err) {
+                                status = 500;
+                                if (err.indexOf('permissionError') !== -1) {
+                                    status = 401;
+                                }
+                                doResponse(res, responseType, status, headers, {error: JSON.stringify(err)}, values.prettyPrint);
+                            } else {
+                                status = 200;
+                                oId = [];
+                                for (var id in list) {
+                                    if( list.hasOwnProperty(id) ) {
+                                        oId.push(id);
+                                    }                                 
+                                }
+                                doResponse(res, responseType, status, headers, oId, values.prettyPrint);
+                            }
+                        });
+                    }
                     break;
 
                 case 'query':

--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -1213,6 +1213,8 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
             case 'help':
             // is default behaviour too
             default:
+                status = 200;
+
                 const obj = (command === 'help') ? {} : {error: 'command ' + command + ' unknown'};
                 let request = 'http' + (that.settings.secure ? 's' : '') + '://' + req.headers.host;
                 if (this.app) {

--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -297,7 +297,17 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
 
                 case 'query':
                     var targets = JSON.parse(body).targets || [];
+                    var range  = JSON.parse(body).range || {};
+                    let dateFrom = Date.now();
+                    let dateTo = Date.now();
+
                     that.adapter.log.debug("[QUERY] targets = " + JSON.stringify(targets));
+                    that.adapter.log.debug("[QUERY] range = " + JSON.stringify(range));
+
+                    if (range) {
+                        dateFrom = Date.parse(range.from);
+                        dateTo = Date.parse(range.to);
+                    }
                     
                     oId = [];
                     targets.forEach(t => {
@@ -308,34 +318,73 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                         doResponse(res, responseType, status, headers, {error: 'no datapoints given'}, values.prettyPrint);
                         break;
                     }
-                    let bcnt = oId.length;
+                    let bcnt = targets.length;
                     var list = [];
-                    for (let b = 0; b < oId.length; b++) {
-                        getState(oId[b], values.user, (err, state, id, originId) => {
-                            if (err) {
-                                bcnt = 0;
-                                status = 500;
-                                if (err.indexOf('permissionError') !== -1) {
-                                    status = 401;
+                    for (let b = 0; b < targets.length; b++) {
+                        if (that.adapter.config.dataSource && !(targets[b].data && targets[b].data.noHistory === true)) {
+                            that.adapter.log.debug("Read data from: " + that.adapter.config.dataSource);
+
+                            that.adapter.sendTo(that.adapter.config.dataSource, 'getHistory', {
+                                id: targets[b].target,
+                                options: {
+                                    start:      dateFrom,
+                                    end:        dateTo,
+                                    aggregate: 'onchange'
                                 }
-                                doResponse(res, responseType, status, headers, 'error: ' + err, values.prettyPrint);
-                            } else {
-                                if (id) status = 200;
-                                state = state || {};
+                            }, function (result, step, error) {
+                                if (!error) status = 200;
+
+                                that.adapter.log.debug("[QUERY] sendTo result = " + JSON.stringify(result));
 
                                 var element = {};
-                                element.target = id;
-                                element.datapoints = [[state.val, state.ts]];
+                                element.target = targets[b].target;
+                                element.datapoints = [];
+
+                                for (var i = 0; i < result.result.length; i++) {
+                                    var datapoint = [result.result[i].val, result.result[i].ts];
+                                    element.datapoints.push(datapoint);
+                                }
 
                                 list.push(element);
+
                                 if (!--bcnt) {
                                     that.adapter.log.debug("[QUERY] list = " + JSON.stringify(list));
                                     doResponse(res, responseType, status, headers, list, values.prettyPrint);
                                 }
-                            }
-                        });
+                            });
+                        } else {
+                            that.adapter.log.debug("Read last state");
+
+                            getState(targets[b].target, values.user, (err, state, id) => {
+                                var element = {};
+                                element.target = id;
+                                element.datapoints = [];
+
+                                if (err) {
+                                    bcnt = 0;
+                                    status = 500;
+                                    if (err.indexOf('permissionError') !== -1) {
+                                        status = 401;
+                                    }
+                                    doResponse(res, responseType, status, headers, 'error: ' + err, values.prettyPrint);
+                                } else {
+                                    if (id) status = 200;
+                                    state = state || {};
+
+                                    element.datapoints = [[state.val, state.ts]];
+
+                                    list.push(element);
+
+                                    if (!--bcnt) {
+                                        that.adapter.log.debug("[QUERY] list = " + JSON.stringify(list));
+                                        doResponse(res, responseType, status, headers, list, values.prettyPrint);
+                                    }
+                                }
+                            });
+                        }
                     }
                     if (!bcnt) {
+                        that.adapter.log.debug("[QUERY] !bcnt");
                         doResponse(res, responseType, status, headers, list, values.prettyPrint);
                     }
                     break;

--- a/lib/simpleapi.js
+++ b/lib/simpleapi.js
@@ -51,6 +51,9 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
         objects: {type: 'object', operation: 'list'},
         states: {type: 'state', operation: 'list'},
         getStates: {type: 'state', operation: 'list'},
+        search: {type: 'state', operation: 'list'},
+        query: {type: 'state', operation: 'read'},
+        annotations: {type: '', operation: ''},
         help: {type: '', operation: ''}
     };
 
@@ -507,25 +510,6 @@ function SimpleAPI(server, webSettings, adapter, instanceSettings, app) {
                 break;
         }
     }
-
-    // static information
-    const commandsPermissions = {
-        getPlainValue: {type: 'state', operation: 'read'},
-        get: {type: 'state', operation: 'read'},
-        getBulk: {type: 'state', operation: 'read'},
-        set: {type: 'state', operation: 'write'},
-        toggle: {type: 'state', operation: 'write'},
-        setBulk: {type: 'state', operation: 'write'},
-        setValueFromBody: {type: 'state', operation: 'write'},
-        getObjects: {type: 'object', operation: 'list'},
-        objects: {type: 'object', operation: 'list'},
-        states: {type: 'state', operation: 'list'},
-        getStates: {type: 'state', operation: 'list'},
-        search: {type: 'state', operation: 'list'},
-        query: {type: 'state', operation: 'read'},
-        annotations: {type: '', operation: ''},
-        help: {type: '', operation: ''}
-    };
 
     this.commands = [];
     for (const c in commandsPermissions) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.simple-api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "RESTful interface for ioBroker.",
   "author": {
     "name": "bluefox",
@@ -10,6 +10,10 @@
     {
       "name": "Apollon77",
       "email": "ingo@fischer-ka.de"
+    },
+    {
+      "name": "Marco.K",
+      "email": "marco@kaminski-net.de"
     }
   ],
   "homepage": "https://github.com/ioBroker/ioBroker.simple-api",


### PR DESCRIPTION
Some commands have been added to visualize data in Grafana without having to create SQL queries.
For Grafana there are 2 plugins working with the new commands.

In the forum there is a post about it https://forum.iobroker.net/topic/23033/aufruf-modifikation-simpleapi-adapter-iobroker-als-datenquelle-f%C3%BCr-grafana
Issue #17 is then processed.

I had upgraded to version 2.0.3 and adopted the changes from 2.0.4 and 2.0.5.
I have left my changes as version 2.0.3, I hope that's okay.